### PR TITLE
Implemented 'about' slash command

### DIFF
--- a/app/controllers/slackbot_controller.rb
+++ b/app/controllers/slackbot_controller.rb
@@ -1,13 +1,20 @@
-#require 'slack-ruby-client'
-require 'json'
-
 class SlackbotController < ApplicationController
+
   def enable_event_challenge
     if params[:type] == 'url_verification'
         render json: {'challenge': params[:challenge] }.to_json
     end
   end
 
+  def about
+    render json: {"text": "Hello! I'm Joyce Bot. I'm here to have fun and pet your cats! Here are some commands I know: "}.to_json
+  end
+
   def expense
+  end
+
+  private
+  def valid_slack_token?
+    params[:token] == ENV["SLACK_SIGNING_SECRET"]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   post 'slackbot/enable_event_challenge' => 'slackbot#enable_event_challenge'
+  post 'slackbot/about' => 'slackbot#about'
   get 'slackbot/expense'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/message' => 'toys#message'


### PR DESCRIPTION
Basic implementation for the "about" slash command, which will print instructions on how to use slash commands implemented in the future.

![image](https://user-images.githubusercontent.com/17524777/53283243-35e9d780-3711-11e9-8e6b-e6418b986f56.png)

![image](https://user-images.githubusercontent.com/17524777/53283293-2919b380-3712-11e9-8153-a178cf09e4ab.png)

